### PR TITLE
Instructional Offering Detail: Curricula

### DIFF
--- a/JavaSource/org/unitime/timetable/gwt/server/CurriculaServlet.java
+++ b/JavaSource/org/unitime/timetable/gwt/server/CurriculaServlet.java
@@ -1631,6 +1631,7 @@ public class CurriculaServlet implements CurriculaService {
 						curricula: for (CurriculumInterface curriculum: curricula) {
 							for (CurriculumInterface result: results) {
 								if (ToolBox.equals(curriculum.getId(), result.getId()) && ToolBox.equals(curriculum.getAcademicArea().getId(), result.getAcademicArea().getId())) {
+									for (CurriculumClassificationInterface cc: curriculum.getClassifications()) result.addClassification(cc);
 									result.addCourse(curriculum.getCourses().first());
 									continue curricula;
 								}


### PR DESCRIPTION
- fixed the case when a curriculum contains both courses of a cross-list, each in a different classification