### PR TITLE
Fix deprecation warnings

### DIFF
--- a/JavaSource/org/unitime/timetable/onlinesectioning/custom/SectionLimitProvider.java
+++ b/JavaSource/org/unitime/timetable/onlinesectioning/custom/SectionLimitProvider.java
@@ -30,6 +30,7 @@ import org.unitime.timetable.onlinesectioning.AcademicSessionInfo;
  * @author Tomas Muller
  * @deprecated
  */
+@Deprecated
 public interface SectionLimitProvider {
 
 	public int[] getSectionLimit(AcademicSessionInfo session, Long courseId, Section section);

--- a/JavaSource/org/unitime/timetable/onlinesectioning/custom/SectionUrlProvider.java
+++ b/JavaSource/org/unitime/timetable/onlinesectioning/custom/SectionUrlProvider.java
@@ -29,6 +29,7 @@ import org.unitime.timetable.onlinesectioning.AcademicSessionInfo;
  * @author Tomas Muller
  * @deprecated
  */
+@Deprecated
 public interface SectionUrlProvider {
 
 	public URL getSectionUrl(AcademicSessionInfo session, Long courseId, Section section);

--- a/JavaSource/org/unitime/timetable/onlinesectioning/custom/purdue/PurdueSectionLimitProvider.java
+++ b/JavaSource/org/unitime/timetable/onlinesectioning/custom/purdue/PurdueSectionLimitProvider.java
@@ -48,6 +48,7 @@ import org.unitime.timetable.onlinesectioning.custom.SectionUrlProvider;
  * @author Tomas Muller
  * @deprecated
  */
+@Deprecated
 public class PurdueSectionLimitProvider implements SectionLimitProvider, SectionUrlProvider {
 	private static StudentSectioningMessages MSG = Localization.create(StudentSectioningMessages.class);
 	private static Log sLog = LogFactory.getLog(PurdueSectionLimitProvider.class);


### PR DESCRIPTION
```
compile-java:
    [javac] Compiling 2598 source files to /opt/unitime/temp/build
    [javac] /opt/unitime/temp/build/org/unitime/timetable/onlinesectioning/custom/SectionLimitProvider.java:33: warning: [dep-ann] deprecated item is not annotated with @Deprecated
    [javac] public interface SectionLimitProvider {
    [javac]        ^
    [javac] /opt/unitime/temp/build/org/unitime/timetable/onlinesectioning/custom/SectionUrlProvider.java:32: warning: [dep-ann] deprecated item is not annotated with @Deprecated
    [javac] public interface SectionUrlProvider {
    [javac]        ^
    [javac] /opt/unitime/temp/build/org/unitime/timetable/onlinesectioning/custom/purdue/PurdueSectionLimitProvider.java:51: warning: [dep-ann] deprecated item is not annotated with @Deprecated
    [javac] public class PurdueSectionLimitProvider implements SectionLimitProvider, SectionUrlProvider {
    [javac]        ^
    [javac] Note: Some input files use or override a deprecated API.
    [javac] Note: Recompile with -Xlint:deprecation for details.
    [javac] Note: Some input files use unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.
    [javac] 3 warnings
```